### PR TITLE
Import constants from the right location and name export correctly

### DIFF
--- a/src/actions/meldActions.js
+++ b/src/actions/meldActions.js
@@ -83,7 +83,7 @@ export function handleCueAudio(component, annotation, body, uri, fragments) {
     return annotationNotHandled(annotation);
 }
 
-export function handleCueVidio(component, annotation, body, uri, fragments) { 
+export function handleCueVideo(component, annotation, body, uri, fragments) {
     if("MEI" in fragments && "Video" in fragments) { 
         fragments.MEI.map((f) => { 
             const fLocalId = f.substr(f.indexOf("#"))

--- a/src/reducers/reducer_app.js
+++ b/src/reducers/reducer_app.js
@@ -1,6 +1,6 @@
 import update from 'immutability-helper';
-import { CUE_AUDIO_HANDLED } from '../actions/index';
-import { CUE_VIDEO_HANDLED } from '../actions/index';
+import { CUE_AUDIO_HANDLED } from '../actions/meldActions';
+import { CUE_VIDEO_HANDLED } from '../actions/meldActions';
 
 export default function(state = { "audioCuePos": null , "videoCuePos": null}, action) { 
 	switch (action.type) { 


### PR DESCRIPTION
Some files failed to compile when independently building the whole package. I guess this wasn't seen when compiling DigitalScoreEdition as not all files were being used.