### PR TITLE
Remove svg-inline-react because of out-of-date react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-router-dom": "^4.3.1",
     "redux": "^3.0.4",
     "redux-promise": "^0.5.3",
-    "redux-thunk": "~2.2.0",
-    "svg-inline-react": "~3.1.0"
+    "redux-thunk": "~2.2.0"
   }
 }

--- a/src/containers/score.js
+++ b/src/containers/score.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom'
 import { connect } from 'react-redux';
 import { bindActionCreators} from 'redux';
@@ -26,7 +26,6 @@ import {
 } from '../actions/meldActions';
 
 
-import InlineSVG from 'svg-inline-react';
 const defaultVrvOptions = {
 	ignoreLayout:1,
 	adjustPageHeight:1,
@@ -42,8 +41,8 @@ const defaultVrvOptions = {
 };
 
 
-class Score extends Component { 
-	constructor(props) { 
+class Score extends React.Component {
+	constructor(props) {
 		super(props);
 
 		this.state = { 
@@ -81,7 +80,7 @@ class Score extends Component {
 				<div id={this.props.uri} className="scorepane">
 					<div className="controls" />
 					<div className="annotations" />
-					<InlineSVG className="score" src={ svg } />
+					<div dangerouslySetInnerHTML={{__html: svg}} />
 				</div>
 			);
 		}


### PR DESCRIPTION
The latest version of this library uses React.PropTypes, which has been removed in react 16. As it's a very basic wrapper around dangerouslySetInnerHTML, and we don't seem to be using any of its additional features, remove it.