### PR TITLE
Add latest babel for compilation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-react"]
+}

--- a/package.json
+++ b/package.json
@@ -2,28 +2,26 @@
   "name": "meld-clients-core",
   "version": "1.0.0",
   "description": "Music Encoding and Linked Data (MELD) clients core library",
-  "main": "index.js",
+  "main": "lib/index.js",
   "repository": "git@github.com:musicog/meld-clients-core.git",
   "scripts": {
-    "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js"
+    "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
+    "build": "babel src --out-dir lib",
+    "build-dev": "babel src --out-dir lib --source-maps inline"
   },
   "author": "David M. Weigl, David Lewis, Oxford e-Research Centre, University of Oxford",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "babel-core": "^6.2.1",
-    "babel-loader": "^6.2.0",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
+    "@babel/cli": "^7.6.0",
+    "@babel/core": "^7.6.0",
+    "@babel/preset-react": "^7.0.0",
     "chai": "^3.5.0",
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
-    "react-addons-test-utils": "^0.14.7",
-    "webpack": "^1.12.9",
-    "webpack-dev-server": "^1.14.0"
+    "react-addons-test-utils": "^0.14.7"
   },
   "dependencies": {
     "axios": "^0.15.3",
-    "babel-preset-stage-1": "^6.1.18",
     "immutability-helper": "^2.1.2",
     "jsonld": "^0.4.11",
     "jsum": "^0.1.4",
@@ -37,6 +35,7 @@
     "react-media-player": "^0.6.1",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
+    "react-scripts": "^3.1.1",
     "redux": "^3.0.4",
     "redux-promise": "^0.5.3",
     "redux-thunk": "~2.2.0",

--- a/src/library/vrvInstance.js
+++ b/src/library/vrvInstance.js
@@ -1,2 +1,2 @@
-console.log("Arf!");
-export default const vrvTk = new verovio.toolkit();
+const vrvTk = new verovio.toolkit();
+export default vrvTk;


### PR DESCRIPTION
This is part of a 2-step process for compiling this package when it's used as a dependency as a different app. We use babel to transform source files before importing them, which is especially important for source files that include jsx.

Compile with `npm run build`