### PR TITLE
Allow npm link to work with different major versions of react

### DIFF
--- a/lib/containers/orchestralRibbon.js
+++ b/lib/containers/orchestralRibbon.js
@@ -3,8 +3,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchRibbonContent } from '../actions/index';
 import { Orchestration, mergedInstruments, caption, drawBarLines, drawRibbons } from '../library/MEIRibbonUtils';
-import InlineSVG from 'svg-inline-react';
-
 class OrchestralRibbon extends Component {
   constructor(props) {
     super(props);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "redux-promise": "^0.6.0",
     "redux-thunk": "^2.3.0",
     "solid-auth-client": ">=2.4.0 <2.5.0",
-    "svg-inline-react": "^3.2.0",
     "uuid": "^8.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "repository": "git@github.com:musicog/meld-clients-core.git",
   "scripts": {
-    "start": "react-scripts start",
     "build": "babel src --out-dir lib",
     "build-dev": "babel src --out-dir lib --source-maps inline"
   },
@@ -18,6 +17,24 @@
     "chai": "^3.5.0",
     "jsdom": "^8.1.0"
   },
+  "peerDependencies": {
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0",
+    "react-redux": ">=7.2.0",
+    "react-router": ">=5.2.0",
+    "redux": ">=4.0.5",
+    "redux-thunk": ">=2.3.0",
+    "react-3d-carousel": "oerc-music/react-3d-carousel",
+    "react-media-player": "^0.7.9"
+  },
+  "peerDependenciesMeta": {
+    "react-3d-carousel": {
+      "optional": true
+    },
+    "react-media-player": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "axios": "^0.19.0",
     "immutability-helper": "^2.1.2",
@@ -26,16 +43,7 @@
     "leaflet": "^1.2.0",
     "n3": "^1.0.3",
     "querystring": "^0.2.0",
-    "react": "^16.0.0",
-    "react-3d-carousel": "oerc-music/react-3d-carousel",
-    "react-dom": "^16.0.0",
-    "react-media-player": "^0.7.9",
-    "react-redux": "^7.2.0",
-    "react-router": "^5.2.0",
-    "react-scripts": "^4.0.1",
-    "redux": "^4.0.5",
     "redux-promise": "^0.6.0",
-    "redux-thunk": "^2.3.0",
     "solid-auth-client": ">=2.4.0 <2.5.0",
     "uuid": "^8.3.2"
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom": "^16.0.0",
     "react-media-player": "^0.7.9",
     "react-redux": "^7.2.0",
-    "react-router": "latest",
+    "react-router": "^5.2.0",
     "react-scripts": "^4.0.1",
     "redux": "^4.0.5",
     "redux-promise": "^0.6.0",

--- a/src/containers/orchestralRibbon.js
+++ b/src/containers/orchestralRibbon.js
@@ -4,8 +4,6 @@ import {bindActionCreators} from 'redux';
 import {fetchRibbonContent} from '../actions/index';
 import { Orchestration, mergedInstruments, caption, drawBarLines, drawRibbons } from '../library/MEIRibbonUtils';
 
-import InlineSVG from 'svg-inline-react';
-
 class OrchestralRibbon extends Component {
 	constructor(props) {
 		super(props);


### PR DESCRIPTION
Remove unused `npm start` command. This never did anything after m-c-c was broken out into a separate library:

```
> meld-clients-core@2.0.0 start
> react-scripts start

Could not find a required file.
  Name: index.html
  Searched in: /...../meld-clients-core/public
```
[Remove svg-inline-react](https://github.com/oerc-music/meld-clients-core/commit/6a0560da544ac5f23552f0989e5d42b2c7602fd2)

This package doesn't install with newer versions of react, and isn't used anywhere anyway

[Set specific version of react-router](https://github.com/oerc-music/meld-clients-core/commit/e5a851497270a02c5ab36f548402857f77fbe811)

This change was added in https://github.com/oerc-music/meld-clients-core/commit/c494fc80c8b7c8f7ad09a5d36b1adfde13f6a51d but was set to `@latest` in 2020
There's now a new version out which conflicts with our react, revert to
the most up-to-date version that was available when this change was made

[use peerDependencies for react and redux](https://github.com/oerc-music/meld-clients-core/pull/22/commits/113cffe6cec0fb4c188f323919bfb3f6a49e08ef)

If a downstream package uses a different major version of react we'll get a conflict at runtime. use peerDependencies to inform the downstream package of what dependencies we require, but don't install them. Loosen the version requirements to allow newer versions of react.
